### PR TITLE
build(gradle): 更新依赖版本- 将 ruoyi-common-bom 版本从 5.X 更新为 0.1.5

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ therapi-javadoc = '0.15.0'
 # bom libs
 ihub-integration-bom = { module = 'pub.ihub.integration:ihub-bom', version = '0.1.10' }
 ihub-module-bom = { module = 'pub.ihub.module:ihub-bom', version = '0.2.1' }
-#ruoyi-common-bom = { module = 'io.github.ihub-pub:ruoyi-common-bom', version = '5.X-SNAPSHOT' }
+ruoyi-common-bom = { module = 'io.github.ihub-pub:ruoyi-common-bom', version = '0.1.5' }
 hutool-v5-bom = { module = 'cn.hutool:hutool-bom', version.ref = 'hutool-v5' }
 hutool-bom = { module = 'org.dromara.hutool:hutool-bom', version.ref = 'hutool' }
 mybatis-plus-bom = { module = 'com.baomidou:mybatis-plus-bom', version = '3.5.9' }
@@ -24,7 +24,7 @@ mybatis-plus-bom = { module = 'com.baomidou:mybatis-plus-bom', version = '3.5.9'
 spring-ai-bom = { module = 'io.github.pig-mesh.ai:spring-ai-bom', version = '1.3.0' }
 spock-bom = { module = 'org.spockframework:spock-bom', version = '2.3-groovy-4.0' }
 sa-token-bom = { module = 'cn.dev33:sa-token-bom', version = '1.39.0' }
-anyline-dependency = { module = 'org.anyline:anyline-dependency', version = '8.7.2-20250101' }
+anyline-dependency = { module = 'org.anyline:anyline-dependency', version = '8.7.2-20250102' }
 spring-boot-admin-dependencies = { module = 'de.codecentric:spring-boot-admin-dependencies', version.ref = 'spring-boot-admin' }
 spring-cloud-dependencies = { module = 'org.springframework.cloud:spring-cloud-dependencies', version.ref = 'spring-cloud' }
 spring-cloud-alibaba-dependencies = { module = 'com.alibaba.cloud:spring-cloud-alibaba-dependencies', version.ref = 'spring-cloud-alibaba' }
@@ -127,7 +127,7 @@ dynamic-datasource = { module = 'com.baomidou:dynamic-datasource-spring-boot3-st
 
 [bundles]
 platform = [
-    'ihub-integration-bom', 'ihub-module-bom', 'hutool-bom',
+    'ihub-integration-bom', 'ihub-module-bom', 'ruoyi-common-bom', 'hutool-bom',
     'hutool-v5-bom', 'jmolecules-bom', 'spock-bom', 'sa-token-bom',
     'mybatis-plus-bom', 'spring-modulith-bom', 'spring-ai-bom', 'spring-boot-admin-dependencies',
     'spring-cloud-dependencies', 'spring-cloud-alibaba-dependencies', 'spring-boot-dependencies',


### PR DESCRIPTION
[![](https://www.codefactor.io/repository/github/ihub-pub/libs/badge)](https://www.codefactor.io/repository/github/ihub-pub/libs) [![](https://codecov.io/gh/ihub-pub/libs/branch/main/graph/badge.svg?token=ZQ0WR3ZSWG)](https://codecov.io/gh/ihub-pub/libs) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=ihub-pub&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- 更新 anyline-dependency 版本从 8.7.2-20250101 到8.7.2-20250102
- 在 platform 束中添加 ruoyi-common-bom