### PR TITLE
build: 更新依赖版本并调整项目配置

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ therapi-javadoc = '0.15.0'
 # bom libs
 ihub-integration-bom = { module = 'pub.ihub.integration:ihub-bom', version = '0.1.10' }
 ihub-module-bom = { module = 'pub.ihub.module:ihub-bom', version = '0.2.1' }
-ruoyi-common-bom = { module = 'io.github.ihub-pub:ruoyi-common-bom', version = '0.1.5' }
+ruoyi-common-bom = { module = 'io.github.ihub-pub:ruoyi-common-bom', version = '5.2.3' }
 hutool-v5-bom = { module = 'cn.hutool:hutool-bom', version.ref = 'hutool-v5' }
 hutool-bom = { module = 'org.dromara.hutool:hutool-bom', version.ref = 'hutool' }
 mybatis-plus-bom = { module = 'com.baomidou:mybatis-plus-bom', version = '3.5.9' }
@@ -30,7 +30,7 @@ spring-cloud-dependencies = { module = 'org.springframework.cloud:spring-cloud-d
 spring-cloud-alibaba-dependencies = { module = 'com.alibaba.cloud:spring-cloud-alibaba-dependencies', version.ref = 'spring-cloud-alibaba' }
 spring-boot-dependencies = { module = 'org.springframework.boot:spring-boot-dependencies', version.ref = 'spring-boot' }
 #dante-cloud-dependencies = { module = 'cn.herodotus.engine:dependencies', version = '3.4.1.0' }
-springdoc-openapi-dependencies = { module = 'org.springdoc:springdoc-openapi', version = '2.7.0' }
+springdoc-openapi-dependencies = { module = 'org.springdoc:springdoc-openapi', version = '2.8.0' }
 
 # native
 #solon-bom = { module = 'org.noear:solon-parent', version = '3.0.5' }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,11 +16,11 @@
 import pub.ihub.plugin.IHubSettingsExtension
 
 plugins {
-    id("pub.ihub.plugin.ihub-settings") version "1.7.3"
+    id("pub.ihub.plugin.ihub-settings") version "1.7.4"
 }
 
 configure<IHubSettingsExtension> {
     includeProjects("ihub-core").subproject
     includeProjects("ihub-starter").prefix("ihub-boot-").suffix("-spring-boot-starter").onlySubproject
-    includeProjects("ihub-sso").subproject.suffix("-spring-boot-starter")
+//    includeProjects("ihub-sso").subproject.suffix("-spring-boot-starter")
 }


### PR DESCRIPTION
[![](https://www.codefactor.io/repository/github/ihub-pub/libs/badge)](https://www.codefactor.io/repository/github/ihub-pub/libs) [![](https://codecov.io/gh/ihub-pub/libs/branch/main/graph/badge.svg?token=ZQ0WR3ZSWG)](https://codecov.io/gh/ihub-pub/libs) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=ihub-pub&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- 将 ruoyi-common-bom 版本从0.1.5 升级到 5.2.3- 将 springdoc-openapi依赖版本从 2.7.0 升级到 2.8.0
- 将 pub.ihub.plugin.ihub-settings 插件版本从 1.7.3 升级到1.7.4
- 注释掉 ihub-sso 子项目的包含配置