### PR TITLE
build(deps): 更新 dynamic-tp-dependencies 版本并调整 Dependabot 配置

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
     commit-message:
       prefix: "build(deps)"
     ignore:
-      - dependency-name: "org.dromara.dynamictp:*"
+      - dependency-name: "org.dromara.dynamictp:dynamic-tp-dependencies"
         version: ["1.2.0-x"]
 
   - package-ecosystem: github-actions

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ spring-boot-dependencies = { module = 'org.springframework.boot:spring-boot-depe
 #dante-cloud-dependencies = { module = 'cn.herodotus.engine:dependencies', version = '3.4.1.0' }
 springdoc-openapi-dependencies = { module = 'org.springdoc:springdoc-openapi', version = '2.8.6' }
 # 动态可监控线程
-dynamic-tp-dependencies = { module = 'org.dromara.dynamictp:dynamic-tp-dependencies', version = '1.2.0-x' }
+dynamic-tp-dependencies = { module = 'org.dromara.dynamictp:dynamic-tp-dependencies', version = '1.2.0' }
 # 数据翻译
 easy-trans-dependencies = { module = 'org.dromara:easy-trans-dependencies', version = '3.1.2' }
 # 工作流


### PR DESCRIPTION
[![](https://www.codefactor.io/repository/github/ihub-pub/libs/badge)](https://www.codefactor.io/repository/github/ihub-pub/libs) [![](https://codecov.io/gh/ihub-pub/libs/branch/main/graph/badge.svg?token=ZQ0WR3ZSWG)](https://codecov.io/gh/ihub-pub/libs) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=ihub-pub&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

-将 dynamic-tp-dependencies 版本从 1.2.0-x 修改为 1.2.0
- 更新 Dependabot配置，仅忽略 dynamic-tp-dependencies 的更新
- 移除 github-actions 配置部分