### PR TITLE
build(deps): 更新依赖版本并忽略特定版本

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,9 @@ updates:
       - dependency-type: "production"
     commit-message:
       prefix: "build(deps)"
+    ignore:
+      - dependency-name: "org.dromara.dynamictp:dynamic-tp-dependencies"
+        versions: ["1.2.0-x"]
 
   - package-ecosystem: github-actions
     directory: /

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ pmd = '7.12.0'
 snailjob = '1.4.0'
 skywalking-toolkit = '9.4.0'
 therapi-javadoc = '0.15.0'
-mpe = '3.5.10.1-EXT832'
+mpe = '3.5.11-EXT833'
 
 [libraries]
 # bom libs
@@ -30,7 +30,7 @@ spring-boot-dependencies = { module = 'org.springframework.boot:spring-boot-depe
 #dante-cloud-dependencies = { module = 'cn.herodotus.engine:dependencies', version = '3.4.1.0' }
 springdoc-openapi-dependencies = { module = 'org.springdoc:springdoc-openapi', version = '2.8.6' }
 # 动态可监控线程
-dynamic-tp-dependencies = { module = 'org.dromara.dynamictp:dynamic-tp-dependencies', version = '1.2.0-x' }
+dynamic-tp-dependencies = { module = 'org.dromara.dynamictp:dynamic-tp-dependencies', version = '1.2.0' }
 # 数据翻译
 easy-trans-dependencies = { module = 'org.dromara:easy-trans-dependencies', version = '3.1.2' }
 # 工作流


### PR DESCRIPTION
[![](https://www.codefactor.io/repository/github/ihub-pub/libs/badge)](https://www.codefactor.io/repository/github/ihub-pub/libs) [![](https://codecov.io/gh/ihub-pub/libs/branch/main/graph/badge.svg?token=ZQ0WR3ZSWG)](https://codecov.io/gh/ihub-pub/libs) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=ihub-pub&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- 更新 mpe 版本至 3.5.11-EXT833
- 将 dynamic-tp-dependencies 版本从 1.2.0-x 修改为 1.2.0
- 在 dependabot 配置中忽略 dynamic-tp-dependencies 的 1.2.0-x 版本