### PR TITLE
build(deps): 更新 dynamic-tp 依赖版本并调整依赖配置- 将 dynamic-tp-dependencies 版本从…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,7 @@ updates:
       prefix: "build(deps)"
     ignore:
       - dependency-name: "org.dromara.dynamictp:dynamic-tp-dependencies"
-        versions: ["1.2.0-x"]
+        versions: ["1.2.2-x", "1.2.3-x", "1.2.4-x", "1.2.5-x", "1.2.6-x", "1.2.7-x", "1.2.8-x", "1.2.9-x"]
 
   - package-ecosystem: github-actions
     directory: /

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,11 +33,7 @@ spring-cloud-alibaba-dependencies = { module = 'com.alibaba.cloud:spring-cloud-a
 spring-boot-dependencies = { module = 'org.springframework.boot:spring-boot-dependencies', version.ref = 'spring-boot' }
 #dante-cloud-dependencies = { module = 'cn.herodotus.engine:dependencies', version = '3.4.1.0' }
 # 动态可监控线程
-dynamic-tp-dependencies = { module = 'org.dromara.dynamictp:dynamic-tp-dependencies', version = '1.2.2-x' }
-# 数据翻译
-easy-trans-dependencies = { module = 'org.dromara:easy-trans-dependencies', version = '3.1.2' }
-# 工作流
-warm-flow = { module = 'org.dromara.warm:warm-flow', version = '1.7.3' }
+dynamic-tp-dependencies = { module = 'org.dromara.dynamictp:dynamic-tp-dependencies', version = '1.2.2' }
 
 # native
 #solon-bom = { module = 'org.noear:solon-parent', version = '3.0.5' }


### PR DESCRIPTION
[![](https://www.codefactor.io/repository/github/ihub-pub/libs/badge)](https://www.codefactor.io/repository/github/ihub-pub/libs) [![](https://codecov.io/gh/ihub-pub/libs/branch/main/graph/badge.svg?token=ZQ0WR3ZSWG)](https://codecov.io/gh/ihub-pub/libs) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=ihub-pub&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

… 1.2.2-x 修改为 1.2.2

- 移除了 easy-trans-dependencies 和 warm-flow依赖
- 更新了 .github/dependabot.yml 中的 dynamic-tp 版本忽略列表