### PR TITLE
fix(catalog): 修复 catalog CI 校验未生效与脚本非幂等问题

### DIFF
--- a/.github/workflows/catalog-check.yml
+++ b/.github/workflows/catalog-check.yml
@@ -1,0 +1,48 @@
+name: Catalog Consistency Check
+on:
+  push:
+    branches: main
+    paths:
+      - 'gradle/libs.versions.toml'
+      - 'gradle/ihub-catalog/**'
+  pull_request:
+    branches: main
+    paths:
+      - 'gradle/libs.versions.toml'
+      - 'gradle/ihub-catalog/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  catalog-check:
+    name: Verify catalog ↔ toml consistency
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          disable-sudo: true
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Merge domain JSONs into catalog.json
+        run: python3 gradle/ihub-catalog/scripts/merge_catalog.py
+
+      - name: Check catalog ↔ toml consistency
+        run: python3 gradle/ihub-catalog/scripts/validate_catalog.py
+
+      - name: Verify catalog.json is up-to-date
+        run: |
+          if ! git diff --exit-code gradle/ihub-catalog/catalog.json; then
+            echo "::error::catalog.json is out of date. Run merge-catalog.py and commit the result."
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.github
 .gitee
 logs
 pom.xml

--- a/gradle/ihub-catalog/catalog.json
+++ b/gradle/ihub-catalog/catalog.json
@@ -1,6 +1,6 @@
 {
   "catalog_version": "1.0.0",
-  "generated": "2026-07-26",
+  "generated": "a2a4e37a",
   "taxonomy": {
     "catalog_version": "1.0.0",
     "generated": "2026-05-03",

--- a/gradle/ihub-catalog/scripts/merge_catalog.py
+++ b/gradle/ihub-catalog/scripts/merge_catalog.py
@@ -4,10 +4,10 @@
 用法：python3 merge_catalog.py
 输出：gradle/ihub-catalog/catalog.json
 """
+import hashlib
 import json
 import os
 import sys
-from datetime import date
 
 CATALOG_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DOMAINS_DIR = os.path.join(CATALOG_DIR, 'domains')
@@ -28,6 +28,10 @@ def main():
         f for f in os.listdir(DOMAINS_DIR) if f.endswith('.json')
     )
 
+    content_hash = hashlib.sha256()
+    with open(TAXONOMY_FILE, 'rb') as f:
+        content_hash.update(f.read())
+
     for fname in domain_files:
         fpath = os.path.join(DOMAINS_DIR, fname)
         with open(fpath) as f:
@@ -36,10 +40,13 @@ def main():
             print(f'ERROR: {fname} is not a JSON array', file=sys.stderr)
             sys.exit(1)
         components.extend(entries)
+        with open(fpath, 'rb') as f:
+            content_hash.update(f.read())
 
     catalog = {
         'catalog_version': taxonomy.get('catalog_version', '1.0.0'),
-        'generated': str(date.today()),
+        # 内容哈希（幂等）：仅当源文件变化时才改变，避免跨天误报
+        'generated': content_hash.hexdigest()[:8],
         'taxonomy': taxonomy,
         'components': components,
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ easy-query = '3.2.6'
 
 [libraries]
 # ── Infrastructure (BOM / Platform) ────────────────────────────────────────
-ihub-integration-bom = { module = 'pub.ihub.integration:ihub-bom', version = '0.2.4' }
+ihub-integration-bom = { module = 'pub.ihub.integration:ihub-bom', version = '0.2.5' }
 ihub-module-bom = { module = 'pub.ihub.module:ihub-bom', version = '0.3.0' }
 # ── Utilities ──────────────────────────────────────────────────────────────
 hutool-bom = { module = 'cn.hutool:hutool-bom', version.ref = 'hutool' }


### PR DESCRIPTION
## 背景

进度审计（2026-08-22）发现 catalog 一致性保护实际未生效：

1. .gitignore 第 1 行 .github 规则屏蔽了 catalog-check.yml，workflow 从未入库（远端无此 workflow）
2. catalog-check.yml 引用的脚本路径不存在（写的是 gradle/ihub-catalog/merge-catalog.py 与 check-consistency.py，实际为 scripts/merge_catalog.py 与 scripts/validate_catalog.py）
3. merge_catalog.py 每次运行将当天日期写入 generated 字段，非幂等，workflow 的 git diff --exit-code 检查会跨天误报

## 修复

- 移除 .gitignore 的 .github 规则，提交 catalog-check.yml
- 修正 workflow 脚本路径
- generated 字段改为源文件（taxonomy + 13 个 domain 文件）内容哈希前 8 位，仅在源文件变化时改变
- 重新生成 catalog.json

## 验证

- merge_catalog.py 连续运行两次输出完全一致（幂等）
- validate_catalog.py：39 组件 × 13 领域，toml ↔ catalog 全部通过

## 后续

- catalog 条目 39 < 50 目标：扩容在单独分支进行